### PR TITLE
Cl 46

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Do not track the debian package
+*.deb

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pyrsistent"]
 	path = pyrsistent
-	url = https://github.com/tobgu/pyrsistent.git
+	url = https://github.com/Ultimaker/pyrsistent.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pyrsistent"]
+	path = pyrsistent
+	url = https://github.com/tobgu/pyrsistent.git

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+SRC_PATH="$(pwd)"
+MODULE_PATH="$(pwd)/pyrsistent"
+
+init() {
+	git submodule update --init --recursive
+}
+
+build() {
+	cd "${MODULE_PATH}" &&
+	python3 setup.py --command-packages=stdeb.command bdist_deb &&
+	cp deb_dist/python3-pyrsistent_*.deb "${SRC_PATH}/"
+	cd "${SRC_PATH}"
+}
+
+init
+build


### PR DESCRIPTION
Create standard debian package for python3-pyrsistent.

Note, there is a TODO left: currently, the package is built only for the current architecture, thus to create an arm package, we need to create the package on an armhf platform. We need to see how to cross-compile the package to properly fix this.